### PR TITLE
Review for `079cb7f`

### DIFF
--- a/ec-divisors-contest/benches/divisors.rs
+++ b/ec-divisors-contest/benches/divisors.rs
@@ -13,6 +13,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 // ../ec-divisors-contest-src
 fn bench_scalar_mul_divisors(c: &mut Criterion) {
     let mut group = c.benchmark_group("ec-divisors");
+    group.measurement_time(core::time::Duration::from_secs(60));
 
     let point = EdwardsPoint::generator();
     let rand_scalar = <Ed25519 as Ciphersuite>::F::random(&mut OsRng);
@@ -22,12 +23,12 @@ fn bench_scalar_mul_divisors(c: &mut Criterion) {
 
     // Run the benchmark for the reference implementation
     group.bench_function("reference-impl", |b| {
-        b.iter(|| run_bench_ref(&point, &rand_scalar))
+        b.iter_with_large_drop(|| run_bench_ref(&point, &rand_scalar))
     });
 
     // Run the benchmark for the contest implementation
     group.bench_function("contest-impl", |b| {
-        b.iter(|| run_bench_contest(&point, &rand_scalar))
+        b.iter_with_large_drop(|| run_bench_contest(&point, &rand_scalar))
     });
 
     group.finish();

--- a/ec-divisors-contest/src/lib.rs
+++ b/ec-divisors-contest/src/lib.rs
@@ -29,14 +29,14 @@ pub fn check_init_contest(point: &EdwardsPoint, scalar: &Scalar) {
     let (_, _) = <EdwardsPoint as DivisorCurve>::to_xy(*point).expect("zero scalar was decomposed");
 }
 
-pub fn run_bench_ref(point: &EdwardsPoint, scalar: &Scalar) -> PolyRef<FieldElement> {
+pub fn run_bench_ref(point: &EdwardsPoint, scalar: &Scalar) -> (PolyRef<FieldElement>, ScalarDecompositionRef<Scalar>) {
     let scalar = ScalarDecompositionRef::new(*scalar).unwrap();
-    scalar.scalar_mul_divisor(*point)
+    (scalar.scalar_mul_divisor(*point), scalar)
 }
 
-pub fn run_bench_contest(point: &EdwardsPoint, scalar: &Scalar) -> Poly<FieldElement> {
+pub fn run_bench_contest(point: &EdwardsPoint, scalar: &Scalar) -> (Poly<FieldElement>, ScalarDecomposition<Scalar>) {
     let scalar = ScalarDecomposition::new(*scalar).unwrap();
-    scalar.scalar_mul_divisor(*point)
+    (scalar.scalar_mul_divisor(*point), scalar)
 }
 
 // For error: no global memory allocator found but one is required; link to std or add `#[global_allocator]` to a static item that implements the GlobalAlloc trait

--- a/ec-divisors-contest/tests/divisors.rs
+++ b/ec-divisors-contest/tests/divisors.rs
@@ -23,8 +23,8 @@ fn divisors_contest_test() {
         check_init_contest(&point, &scalar);
 
         // Get divisors
-        let ref_res = run_bench_ref(&point, &scalar);
-        let res = run_bench_contest(&point, &scalar);
+        let ref_res = run_bench_ref(&point, &scalar).0;
+        let res = run_bench_contest(&point, &scalar).0;
 
         assert_eq!(ref_res.y_coefficients, res.y_coefficients);
         assert_eq!(ref_res.yx_coefficients, res.yx_coefficients);


### PR DESCRIPTION
I've looked over the files mentioned in https://github.com/monero-project/meta/issues/1162#issuecomment-2691252058 on 079cb7f6c81743f39efa9a6916fb3f35fac3dac7 and ran tests/benchmarks, all seem good. This PR contains a couple pedantic changes to `ec-divisors-contest/benches`, I also left some questions here: https://github.com/j-berman/fcmp-plus-plus-optimization-competition/issues/3.